### PR TITLE
revise the terminology in socket/ip_address_type.md: change 'array of bytes' to 'byte slices'

### DIFF
--- a/socket/ip_address_type.md
+++ b/socket/ip_address_type.md
@@ -1,6 +1,6 @@
 ## IP address type
 
-The package `"net"` defines many types, functions and methods of use in Go network programming. The type `IP` is defined as an array of bytes 
+The package `"net"` defines many types, functions and methods of use in Go network programming. The type `IP` is defined as byte slices 
 
 ```go
 type IP []byte


### PR DESCRIPTION
In Golang, an `array` must specify its size, like this:

`var n [5]byte`

If you omit the size, then it is declared as `slice`, like this:

`var n[]byte`