### PR TITLE
Change "ip4" parameter to "tcp4"

### DIFF
--- a/socket/tcp_sockets.md
+++ b/socket/tcp_sockets.md
@@ -259,7 +259,7 @@ import (
 func main() {
 
 	service := ":1201"
-	tcpAddr, err := net.ResolveTCPAddr("ip4", service)
+	tcpAddr, err := net.ResolveTCPAddr("tcp4", service)
 	checkError(err)
 
 	listener, err := net.ListenTCP("tcp", tcpAddr)


### PR DESCRIPTION
In the net.ResolveTCPAddr() function call, "ip4" was passed in as a parameter where it should have been "tcp4". It currently creates the error : "Fatal error: unknown network ip4"