### PR TITLE
Correct little endian identification

### DIFF
--- a/encoding/utf-16_and_go.md
+++ b/encoding/utf-16_and_go.md
@@ -154,7 +154,7 @@ func readShorts(conn net.Conn) []uint16 {
 		for i := 2; i < n; i += 2 {
 			shorts[i/2] = uint16(buf[i])<<8 + uint16(buf[i+1])
 		}
-	} else if buf[1] == 0xff && buf[0] == 0xfe {
+	} else if buf[1] == 0xfe && buf[0] == 0xff {
 		// little endian
 		for i := 2; i < n; i += 2 {
 			shorts[i/2] = uint16(buf[i+1])<<8 + uint16(buf[i])


### PR DESCRIPTION
Noticed that little endian identifier was the same as big endian.