### PR TITLE
Change Gen to Read

### DIFF
--- a/security/x509_certificates.md
+++ b/security/x509_certificates.md
@@ -92,7 +92,7 @@ func checkError(err error) {
 This can then be read back in by
 
 ```go
-/* GenX509Cert
+/* ReadX509Cert
  */
 
 package main


### PR DESCRIPTION
We already create a `GenX509Cert` in the previous example. I figured `Read` would be the appropriate name for the second example where we are reading in the cert.