### PR TITLE
Typo fix communications_models.md

### DIFF
--- a/architecture/communications_models.md
+++ b/architecture/communications_models.md
@@ -18,7 +18,7 @@ In any system, there is a transfer of information and flow control from one part
 
 Even with procedure calls, there are variations. The code may be statically linked so that control transfers from one part of the program's executable code to another part. Due to the increasing use of library routines, it has become commonplace to have such code in dynamic link libraries (DLL-s), where control transfers to an independent piece of code.
 
-DLLs run in the same machine as the calling code. it is a simple (conceptual) step to transfer control to a procedure running in a different machine. The mechanics of this are not so simple! However, this model of control has given rise to the "remote procedure call" (RPC) which is discussed in much detail in a later chapter. This is illustrated by 
+DLLs run in the same machine as the calling code. It is a simple (conceptual) step to transfer control to a procedure running in a different machine. The mechanics of this are not so simple! However, this model of control has given rise to the "remote procedure call" (RPC) which is discussed in much detail in a later chapter. This is illustrated by 
 
 ![rpc](../assets/rpc.gif)
 


### PR DESCRIPTION
`. it` to `. It`