### PR TITLE
add strings.ToUpper

### DIFF
--- a/http/simple_user-agents.md
+++ b/http/simple_user-agents.md
@@ -146,7 +146,7 @@ func acceptableCharset(contentTypes []string) bool {
 	// each type is like [text/html; charset=UTF-8]
 	// we want the UTF-8 only
 	for _, cType := range contentTypes {
-		if strings.Index(cType, "UTF-8") != -1 {
+		if strings.Index(strings.ToUpper(cType), "UTF-8") != -1 {
 			return true
 		}
 	}


### PR DESCRIPTION
there is issue with some website return `"UTF-8"` as a lowercase so we need to make sure that it is will match correctly. 