### PR TITLE
Google+ link removed

### DIFF
--- a/overview/README.md
+++ b/overview/README.md
@@ -1,4 +1,4 @@
-# Chapter 2 Overview of Go languange
+# Chapter 2 Overview of Go language
 
 I don't feel like writing a chapter introducing Go right now, as there are other materials already available. There are several tutorials on the Go web site:
 
@@ -8,10 +8,4 @@ I don't feel like writing a chapter introducing Go right now, as there are other
 
 There is an introductory textbook on Go: "Go Programming" by John P. Baugh available from [Amazon][1]
 
-There is a [#golang][2] group on Google+ 
-
-
-
 [1]: http://www.amazon.com/Go-Programming-John-P-Baugh/dp/1453636676/ref=sr_1_1?s=books&ie=UTF8&qid=1294310361&sr=1-1
-
-[2]: https://plus.google.com/u/0/s/%23Golang


### PR DESCRIPTION
the Overview (of Go language) page used to contain a link to google+
the link has been removed because Google+ no longer exists

Also corrected “languange” to language in the title of the page